### PR TITLE
Add git URL

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,5 +1,6 @@
 Package.describe({
   summary: "send email via Mandrill"
+  git: "https://github.com/timmyg/meteor-mandrill.git",
 });
 
 Package.on_use(function(api) {


### PR DESCRIPTION
The readme isn't displayed in atmosphere without a git url specified. (https://archive.today/GdtkT)
